### PR TITLE
Add 'oscar/' prefix to extend statement in templates that extend base…

### DIFF
--- a/src/oscar/templates/oscar/basket/basket.html
+++ b/src/oscar/templates/oscar/basket/basket.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 {% load thumbnail %}
 {% load i18n %}
 

--- a/src/oscar/templates/oscar/catalogue/detail.html
+++ b/src/oscar/templates/oscar/catalogue/detail.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 
 {% load history_tags %}
 {% load currency_filters %}

--- a/src/oscar/templates/oscar/catalogue/reviews/review_detail.html
+++ b/src/oscar/templates/oscar/catalogue/reviews/review_detail.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 {% load i18n %}
 
 {% block title %}

--- a/src/oscar/templates/oscar/catalogue/reviews/review_list.html
+++ b/src/oscar/templates/oscar/catalogue/reviews/review_list.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 
 {% load history_tags %}
 {% load i18n %}

--- a/src/oscar/templates/oscar/checkout/layout.html
+++ b/src/oscar/templates/oscar/checkout/layout.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 {% load i18n %}
 {% load promotion_tags %}
 {% load category_tags %}

--- a/src/oscar/templates/oscar/customer/anon_order.html
+++ b/src/oscar/templates/oscar/customer/anon_order.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 {% load currency_filters %}
 {% load i18n %}
 {% load reviews_tags %}

--- a/src/oscar/templates/oscar/customer/login_registration.html
+++ b/src/oscar/templates/oscar/customer/login_registration.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 {% load i18n %}
 
 {% block title %}

--- a/src/oscar/templates/oscar/customer/registration.html
+++ b/src/oscar/templates/oscar/customer/registration.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 
 {% load i18n %}
 

--- a/src/oscar/templates/oscar/dashboard/base.html
+++ b/src/oscar/templates/oscar/dashboard/base.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "oscar/base.html" %}
 
 {% block extrahead %}
     {{ block.super }}

--- a/src/oscar/templates/oscar/error.html
+++ b/src/oscar/templates/oscar/error.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 {% load i18n %}
 
 {% block layout %}

--- a/src/oscar/templates/oscar/flatpages/default.html
+++ b/src/oscar/templates/oscar/flatpages/default.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 {% load i18n %}
 
 {% block title %}

--- a/src/oscar/templates/oscar/layout.html
+++ b/src/oscar/templates/oscar/layout.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "oscar/base.html" %}
 {% load staticfiles %}
 {% load promotion_tags %}
 

--- a/src/oscar/templates/oscar/layout_2_col.html
+++ b/src/oscar/templates/oscar/layout_2_col.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 {% load promotion_tags %}
 
 {% comment %}

--- a/src/oscar/templates/oscar/layout_3_col.html
+++ b/src/oscar/templates/oscar/layout_3_col.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 {% load promotion_tags %}
 
 {% block content_wrapper %}

--- a/src/oscar/templates/oscar/offer/detail.html
+++ b/src/oscar/templates/oscar/offer/detail.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 
 
 {% load i18n %}

--- a/src/oscar/templates/oscar/offer/list.html
+++ b/src/oscar/templates/oscar/offer/list.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 
 
 {% load i18n %}

--- a/src/oscar/templates/oscar/offer/range.html
+++ b/src/oscar/templates/oscar/offer/range.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "oscar/layout.html" %}
 {% load basket_tags %}
 {% load promotion_tags %}
 {% load category_tags %}


### PR DESCRIPTION
….html or layout.html.

- {% extends "base.html" %} -> {% extends "oscar/base.html" %}
- {% extends "layout.html" %} -> {% extends "oscar/layout.html" %}

This allows having independent base.html and layout.html in template root.

Other templates remain untouched, and e.g. creating template dashboard/layout.html will still override oscar/dashboard/layout.html.